### PR TITLE
Added channel positions for PA channels & merged ARA channels.

### DIFF
--- a/include/nuphaseCalibrationInfo.h
+++ b/include/nuphaseCalibrationInfo.h
@@ -1,6 +1,7 @@
 #ifndef NUPHASE_CALIBRATION_INFO_HH
 #define NUPHASE_CALIBRATION_INFO_HH
 
+#include <vector>
 #include "TObject.h" 
 #include "nuphaseConsts.h" 
 
@@ -25,6 +26,11 @@ namespace nuphase
       units getTimeUnits()const  { return t; }
       units getVoltageUnits()const  { return v; }
 
+      std::vector<double> getChanPosition(int chan, board b = BOARD_MASTER) const;
+      double getChanPositionX(int chan, board b = BOARD_MASTER) const { return chan_position[b][chan][0]; }
+      double getChanPositionY(int chan, board b = BOARD_MASTER) const { return chan_position[b][chan][1]; }
+      double getChanPositionZ(int chan, board b = BOARD_MASTER) const { return chan_position[b][chan][2]; }
+
     private: 
       double time_calibration; 
       double voltage_calibration[k::num_boards][k::num_chans_per_board]; 
@@ -34,7 +40,9 @@ namespace nuphase
       double nuphase_fiber_length[k::num_boards][k::num_chans_per_board];
       double nuphase_fiber_delay;
 
-      ClassDef(CalibrationInfo,2); 
+      double chan_position[k::num_boards][k::num_chans_per_board][3];
+
+      ClassDef(CalibrationInfo,3); 
   }; 
 
 }

--- a/src/CalibrationInfo.cc
+++ b/src/CalibrationInfo.cc
@@ -22,5 +22,33 @@ nuphase::CalibrationInfo::CalibrationInfo()
     }
   }
 
-  v = UNITS_ADC; 
+  v = UNITS_ADC;
+
+  // channel positions are relative to top of PA borehole in meters
+  const static double temp_pos[k::num_boards][k::num_chans_per_board][3] = {{ // board 0
+                                                                             {0,0,-172.635}, // 0 (chan 0)
+                                                                             {0,0,-173.65}, // 1 (chan 1)
+                                                                             {0,0,-174.66}, // 2 (chan 2)
+                                                                             {0,0,-175.68}, // 3 (chan 3)
+                                                                             {0,0,-176.70}, // 4 (chan 4)
+                                                                             {12.3309,-31.8967,-190.8559}, // 5 (chan 5 = ARA RFchan 7 =  ARA elecChan 24)
+                                                                             {0,0,-178.75}, // 6 (chan 6)
+                                                                             {0,0,-180.79}}, // 7 (chan 7) 
+                                                                            { // board 1
+                                                                             {0,0,-182.79}, // 0 (chan 8, Hpol positions are a guesstimate ^-^)
+                                                                             {0,0,-183.79}, // 1 (chan 9, Hpol positions are a guesstimate ^-^)
+                                                                             {-12.9616,-8.6511,-177.7466}, // 2 (chan 10 = ARA RFchan 6 =  ARA elecChan 16)
+                                                                             {12.3428,-31.8885,-161.02376}, // 3 (chan 11 = ARA RFchan 3 = ARA elecChan 25)
+                                                                             {1.5493,15.6665,-196.2045}, // 4 (chan 12 = ARA RFchan 5 = ARA elecChan 0)
+                                                                             {1.5458,15.6587,-166.5366}, // 5 (chan 13 = ARA RFchan 1 = ARA elecChan 1)
+                                                                             {29.6505,-3.2845,-194.739}, // 6 (chan 14 = ARA RFchan 4 = ARA elecChan 8)
+                                                                             {29.6347,-3.3004,-165.0948}}}; // 7 (chan 15 = ARA RFchan 0 = ARA elecChan 9)
+  memcpy(chan_position, temp_pos, sizeof(temp_pos));
+}
+
+std::vector<double> nuphase::CalibrationInfo::getChanPosition(int chan, board b)
+  const
+{
+  std::vector<double> v(chan_position[b][chan], chan_position[b][chan] + 3);
+  return v;
 }


### PR DESCRIPTION
Added channel positions based on Kaeli's position calibration. All positions are relative to the top of the PA borehole. ARA channels which were merged after 2019 are also included. PA Hpol positions are guesses based on the Vpol positions.